### PR TITLE
Optimize updating the available parts for Mech Fabricators

### DIFF
--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -73,6 +73,7 @@
 	stored_research = SSresearch.science_tech
 	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init, mat_container_flags=BREAKDOWN_FLAGS_LATHE)
 	RefreshParts() //Recalculating local material sizes if the fab isn't linked
+	update_menu_tech
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/RefreshParts()
@@ -169,10 +170,6 @@
 					category_override += "H.O.N.K"
 				if(mech_types & EXOSUIT_MODULE_PHAZON)
 					category_override += "Phazon"
-
-		else if(ispath(built_item, /obj/item/borg_restart_board))
-			sub_category += "All Cyborgs" //Otherwise the restart board shows in the "parts" category, which seems dumb
-
 
 
 	var/list/part = list(
@@ -461,32 +458,6 @@
 /obj/machinery/mecha_part_fabricator/ui_static_data(mob/user)
 	var/list/data = list()
 
-	var/list/final_sets = list()
-	var/list/buildable_parts = list()
-
-	for(var/part_set in part_sets)
-		final_sets += part_set
-
-	for(var/v in stored_research.researched_designs)
-		var/datum/design/D = SSresearch.techweb_design_by_id(v)
-		if(D.build_type & MECHFAB)
-			// This is for us.
-			var/list/part = output_part_info(D, TRUE)
-
-			if(part["category_override"])
-				for(var/cat in part["category_override"])
-					buildable_parts[cat] += list(part)
-					if(!(cat in part_sets))
-						final_sets += cat
-				continue
-
-			for(var/cat in part_sets)
-				// Find all matching categories.
-				if(!(cat in D.category))
-					continue
-
-				buildable_parts[cat] += list(part)
-
 	data["partSets"] = final_sets
 	data["buildableParts"] = buildable_parts
 
@@ -531,6 +502,7 @@
 	switch(action)
 		if("sync_rnd")
 			// Syncronises designs on interface with R&D techweb.
+			update_menu_tech()
 			update_static_data(usr)
 			say("Successfully synchronized with R&D server.")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It turns out the mech fabricator updated the list of what was available every time anyone opened it, which is incredibly expensive.

In a round, it was the 9th most CPU-overtime intensive proc: (/obj/machinery/mecha_part_fabricator/proc/output_part_info())
![image](https://user-images.githubusercontent.com/41448081/145736967-2e04e6f8-c0c9-4a23-88ba-39ee008d3398.png)

I optimized it to only update the list on Init and when the console is re-synced with the R&D console, in addition to making the proc much, much lighter to run.

Local Testing:
Called the old version 1000 times.
![image](https://user-images.githubusercontent.com/41448081/145737044-c89bc7a1-dd86-4ad4-a75f-fb19977882d6.png)

Called the new version 2000 times.
![image](https://user-images.githubusercontent.com/41448081/145737064-7639ae84-76a8-44cf-a9d8-2c563f554cba.png)

(Yes I tested this, but it was on a downstream, so I did the changes through Github)
## Why It's Good For The Game

Mecha fabricators' menu update proc shouldn't be the 9th most CPU-overloaded proc in an active round, never mind being called 768 times in less than an hour.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Mech Fabricator's `output_part_info()` proc is much more optimized.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
